### PR TITLE
Read form values as snake_case

### DIFF
--- a/src/Opdex.Auth.Api/Conventions/SnakeCaseFormValueProvider.cs
+++ b/src/Opdex.Auth.Api/Conventions/SnakeCaseFormValueProvider.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using O9d.Json.Formatting;
+
+namespace Opdex.Auth.Api.Conventions;
+
+public class SnakeCaseFormValueProvider : FormValueProvider
+{
+    public SnakeCaseFormValueProvider(BindingSource bindingSource, IFormCollection values, CultureInfo? culture)
+        : base(bindingSource, values, culture)
+    {
+    }
+
+    public override bool ContainsPrefix(string prefix) => base.ContainsPrefix(prefix.ToSnakeCase());
+
+    public override ValueProviderResult GetValue(string key) => base.GetValue(key.ToSnakeCase());
+}

--- a/src/Opdex.Auth.Api/Conventions/SnakeCaseValueProviderFactory.cs
+++ b/src/Opdex.Auth.Api/Conventions/SnakeCaseValueProviderFactory.cs
@@ -7,10 +7,16 @@ namespace Opdex.Auth.Api.Conventions;
 
 public class SnakeCaseValueProviderFactory : IValueProviderFactory
 {
-    public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+    public async Task CreateValueProviderAsync(ValueProviderFactoryContext context)
     {
         Guard.Against.Null(context);
-        context.ValueProviders.Add(new SnakeCaseQueryValueProvider(BindingSource.Query, context.ActionContext.HttpContext.Request.Query, CultureInfo.InvariantCulture));
-        return Task.CompletedTask;
+        var request = context.ActionContext.HttpContext.Request;
+        
+        context.ValueProviders.Add(new SnakeCaseQueryValueProvider(BindingSource.Query, request.Query, CultureInfo.InvariantCulture));
+
+        if (!request.HasFormContentType) return;
+        
+        var form = await request.ReadFormAsync();
+        context.ValueProviders.Add(new SnakeCaseFormValueProvider(BindingSource.Form, form, CultureInfo.InvariantCulture));
     }
 }


### PR DESCRIPTION
Enables `code_verifier` to be read as snake case, in accordance to the OAuth2 spec