### PR TITLE
Add sub claim

### DIFF
--- a/src/Opdex.Auth.Api/Encryption/JwtIssuer.cs
+++ b/src/Opdex.Auth.Api/Encryption/JwtIssuer.cs
@@ -50,6 +50,7 @@ public class JwtIssuer : IJwtIssuer
             }
         };
 
+        tokenDescriptor.Subject.AddClaim(new Claim(JwtRegisteredClaimNames.Sub, walletAddress));
         tokenDescriptor.Subject.AddClaim(new Claim("wallet", walletAddress));
 
         var jwt = tokenHandler.CreateToken(tokenDescriptor);


### PR DESCRIPTION
> The "sub" (subject) claim identifies the principal that is the
   subject of the JWT.  The claims in a JWT are normally statements
   about the subject.  The subject value MUST either be scoped to be
   locally unique in the context of the issuer or be globally unique.
   The processing of this claim is generally application specific.  The
   "sub" value is a case-sensitive string containing a StringOrURI
   value.  Use of this claim is OPTIONAL.

Adding the 'sub' claim containing the wallet address makes it a little easier to process using the standard .NET libraries, as we can retrieve the address using `jwt.Subject`, rather than `jwt.Claims.FirstOrDefault(claim => claim.Type == "wallet").Value`. I'd imagine that other packages/languages could come with similar advantages. The sub claim would be familiar to anyone who has worked with JWTs before or who reads the spec.